### PR TITLE
Interface -> Inter UI

### DIFF
--- a/js/example4.js
+++ b/js/example4.js
@@ -2,7 +2,7 @@
   'use strict';
 
   var elements = stripe.elements({
-    cssSrc: 'https://rsms.me/interface/interface.css',
+    cssSrc: 'https://rsms.me/inter/inter-ui.css',
   });
 
   /**
@@ -13,7 +13,7 @@
       base: {
         color: '#32325D',
         fontWeight: 500,
-        fontFamily: 'Interface, Open Sans, Segoe UI, sans-serif',
+        fontFamily: 'Inter UI, Open Sans, Segoe UI, sans-serif',
         fontSize: '15px',
         fontSmoothing: 'antialiased',
 


### PR DESCRIPTION
The Interface font recently rebranded as Inter UI, citing legal concerns from a completely unaffiliated font which shared the same name (Interface)

Further reading: https://github.com/google/fonts/issues/1167