### PR TITLE
move translation id to option

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,8 +350,8 @@
               </div>
               <div class="field">
                 <label for="example5-country" data-tid="elements_examples.form.country_label">Country</label>
-                <select id="example5-country" data-tid="elements_examples.form.country_placeholder" class="input">
-                  <option selected="selected" value="US">United States</option>
+                <select id="example5-country" class="input">
+                  <option selected="selected" value="US" data-tid="elements_examples.form.country_placeholder">United States</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
r? @michelle 

Currently the `data-tid` attribute for the country selector of example 5 is at the `select` element, which means the content (including the `option` element) gets replaced with the translated text content.
This only affects the `en` locale, because the others do not have translations for `elements_examples.form.country_placeholder`.
Moving the `tid` attribute to the `option` element makes sure that the `option` node stays intact and gets populated with the translated text.

The output can be found here: https://github.com/stripe/elements-examples/blob/gh-pages-test-2/index.html