### PR TITLE
replace postalCode element with regular input

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,8 +159,8 @@
               <div class="baseline"></div>
             </div>
             <div class="field quarter-width">
-              <input id="example2-postal-code" data-tid="elements_examples.form.postal_code_placeholder" class="input empty" type="text" placeholder="94107" required="">
-              <label for="example2-postal-code" data-tid="elements_examples.form.postal_code_label">ZIP</label>
+              <input id="example2-zip" data-tid="elements_examples.form.postal_code_placeholder" class="input empty" type="text" placeholder="94107" required="">
+              <label for="example2-zip" data-tid="elements_examples.form.postal_code_label">ZIP</label>
               <div class="baseline"></div>
             </div>
           </div>
@@ -229,7 +229,7 @@
             <div id="example3-card-number" class="field empty"></div>
             <div id="example3-card-expiry" class="field empty third-width"></div>
             <div id="example3-card-cvc" class="field empty third-width"></div>
-            <div id="example3-card-postal-code" class="field empty third-width"></div>
+            <input id="example3-zip" data-tid="elements_examples.form.postal_code_placeholder" class="field empty third-width" placeholder="94107">
           </div>
           <button type="submit" data-tid="elements_examples.form.pay_button">Pay $25</button>
           <div class="error" role="alert"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 17 17">

--- a/js/example3.js
+++ b/js/example3.js
@@ -10,7 +10,7 @@
     // Stripe's examples are localized to specific languages, but if
     // you wish to have Elements automatically detect your user's locale,
     // use `locale: 'auto'` instead.
-    locale: window.__exampleLocale
+    locale: window.__exampleLocale,
   });
 
   var elementStyles = {
@@ -68,14 +68,5 @@
   });
   cardCvc.mount('#example3-card-cvc');
 
-  var cardPostalCode = elements.create('postalCode', {
-    style: elementStyles,
-    classes: elementClasses,
-  });
-  cardPostalCode.mount('#example3-card-postal-code');
-
-  registerElements(
-    [cardNumber, cardExpiry, cardCvc, cardPostalCode],
-    'example3'
-  );
+  registerElements([cardNumber, cardExpiry, cardCvc], 'example3');
 })();


### PR DESCRIPTION
This PR changes example 3 to use a regular input field for postal code collection.

It also changes the id or our 2 postal code input fields so their content [will be included](https://github.com/stripe/elements-examples/blob/1e20b1ce94f6a2fb3fae85eae34b9062c180a967/js/index.js#L58-L70) in the tokenization calls.