### PR TITLE
Improve README for example 3 (no postal code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The form also collects address (and thus postal code) outside of the payment for
 - [JavaScript](js/example3.js)
 - [CSS](css/example3.css)
 
-Example 3 shows a form that uses individual `cardNumber`, `cardExpiry`, `cardCvc`, and `postalCode` Elements with a custom web font.
+Example 3 shows a form that uses individual `cardNumber`, `cardExpiry`, and `cardCvc` Elements with a custom web font.
+
+The form also collects postal code outside of the payment form.
 
 ## Example 4
 


### PR DESCRIPTION
Readme was saying:

> It passes the postal code to Stripe on tokenization.

Which is incorrect. It was correct before, but the following commit was introduced:

https://github.com/stripe/elements-examples/commit/4ab971a29547ec372a964b63423507cc54316824

Commit above prevents the postal code to be posted to Stripe (for some reason, which is unclear). I assume the code is fine, and readme wasn't updated.