### PR TITLE
Show all errors, even if there are multiple

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -44,11 +44,11 @@ function registerElements(elements, exampleName) {
       } else {
         savedErrors[idx] = null;
 
-        // Loop over the saved errors and find the last one, if any.
+        // Loop over the saved errors and find the first one, if any.
         var nextError = Object.keys(savedErrors)
           .sort()
           .reduce(function(maybeFoundError, key) {
-            return savedErrors[key] || maybeFoundError;
+            return maybeFoundError || savedErrors[key];
           }, null);
 
         if (nextError) {

--- a/js/index.js
+++ b/js/index.js
@@ -36,7 +36,6 @@ function registerElements(elements, exampleName) {
   // Listen for errors from each Element, and show error messages in the UI.
   var savedErrors = {};
   elements.forEach(function(element, idx) {
-    savedErrors[idx] = null;
     element.on('change', function(event) {
       if (event.error) {
         error.classList.add('visible');
@@ -45,13 +44,16 @@ function registerElements(elements, exampleName) {
       } else {
         savedErrors[idx] = null;
 
-        var maybeError = Object.keys(savedErrors).reduce(function(acc, key) {
-          return savedErrors[key] || acc;
-        }, null);
+        // Loop over the saved errors and find the last one, if any.
+        var nextError = Object.keys(savedErrors)
+          .sort()
+          .reduce(function(maybeFoundError, key) {
+            return savedErrors[key] || maybeFoundError;
+          }, null);
 
-        if (maybeError) {
+        if (nextError) {
           // Now that they've fixed the current error, show another one.
-          errorMessage.innerText = maybeError;
+          errorMessage.innerText = nextError;
         } else {
           // The user fixed the last error; no more errors.
           error.classList.remove('visible');

--- a/js/index.js
+++ b/js/index.js
@@ -34,13 +34,28 @@ function registerElements(elements, exampleName) {
   }
 
   // Listen for errors from each Element, and show error messages in the UI.
-  elements.forEach(function(element) {
+  var savedErrors = {};
+  elements.forEach(function(element, idx) {
+    savedErrors[idx] = null;
     element.on('change', function(event) {
       if (event.error) {
         error.classList.add('visible');
+        savedErrors[idx] = event.error.message;
         errorMessage.innerText = event.error.message;
       } else {
-        error.classList.remove('visible');
+        savedErrors[idx] = null;
+
+        var maybeError = Object.keys(savedErrors).reduce(function(acc, key) {
+          return savedErrors[key] || acc;
+        }, null);
+
+        if (maybeError) {
+          // Now that they've fixed the current error, show another one.
+          errorMessage.innerText = maybeError;
+        } else {
+          // The user fixed the last error; no more errors.
+          error.classList.remove('visible');
+        }
       }
     });
   });


### PR DESCRIPTION
For split fields if there are ever multiple error messages from the
individual fields, we want to remember them. This way, if we ever
overwrite one with another, we can come back and start showing the old
one again once they've fixed the new one.

Previously, once you fixed the new one it would show you no message, as
if the form were valid.

r? @atty-stripe