### PR TITLE
Make address fields reverse-ordered in Japanese

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,28 +140,30 @@
       <!--Example 2-->
       <div class="cell example example2">
         <form>
-          <div class="row">
-            <div class="field">
-              <input id="example2-address" data-tid="elements_examples.form.address_placeholder" class="input empty" type="text" placeholder="185 Berry St" required="">
-              <label for="example2-address" data-tid="elements_examples.form.address_label">Address</label>
-              <div class="baseline"></div>
+          <div data-locale-reversible>
+            <div class="row">
+              <div class="field">
+                <input id="example2-address" data-tid="elements_examples.form.address_placeholder" class="input empty" type="text" placeholder="185 Berry St" required="">
+                <label for="example2-address" data-tid="elements_examples.form.address_label">Address</label>
+                <div class="baseline"></div>
+              </div>
             </div>
-          </div>
-          <div class="row">
-            <div class="field half-width">
-              <input id="example2-city" data-tid="elements_examples.form.city_placeholder" class="input empty" type="text" placeholder="San Francisco" required="">
-              <label for="example2-city" data-tid="elements_examples.form.city_label">City</label>
-              <div class="baseline"></div>
-            </div>
-            <div class="field quarter-width">
-              <input id="example2-state" data-tid="elements_examples.form.state_placeholder" class="input empty" type="text" placeholder="CA" required="">
-              <label for="example2-state" data-tid="elements_examples.form.state_label">State</label>
-              <div class="baseline"></div>
-            </div>
-            <div class="field quarter-width">
-              <input id="example2-zip" data-tid="elements_examples.form.postal_code_placeholder" class="input empty" type="text" placeholder="94107" required="">
-              <label for="example2-zip" data-tid="elements_examples.form.postal_code_label">ZIP</label>
-              <div class="baseline"></div>
+            <div class="row" data-locale-reversible>
+              <div class="field half-width">
+                <input id="example2-city" data-tid="elements_examples.form.city_placeholder" class="input empty" type="text" placeholder="San Francisco" required="">
+                <label for="example2-city" data-tid="elements_examples.form.city_label">City</label>
+                <div class="baseline"></div>
+              </div>
+              <div class="field quarter-width">
+                <input id="example2-state" data-tid="elements_examples.form.state_placeholder" class="input empty" type="text" placeholder="CA" required="">
+                <label for="example2-state" data-tid="elements_examples.form.state_label">State</label>
+                <div class="baseline"></div>
+              </div>
+              <div class="field quarter-width">
+                <input id="example2-zip" data-tid="elements_examples.form.postal_code_placeholder" class="input empty" type="text" placeholder="94107" required="">
+                <label for="example2-zip" data-tid="elements_examples.form.postal_code_label">ZIP</label>
+                <div class="baseline"></div>
+              </div>
             </div>
           </div>
           <div class="row">
@@ -337,22 +339,26 @@
                 <input id="example5-phone" data-tid="elements_examples.form.phone_placeholder" class="input" type="text" placeholder="(941) 555-0123" required="">
               </div>
             </div>
-            <div class="row">
-              <div class="field">
-                <label for="example5-address" data-tid="elements_examples.form.address_label">Address</label>
-                <input id="example5-address" data-tid="elements_examples.form.address_placeholder" class="input" type="text" placeholder="185 Berry St" required="">
+            <div data-locale-reversible>
+              <div class="row">
+                <div class="field">
+                  <label for="example5-address" data-tid="elements_examples.form.address_label">Address</label>
+                  <input id="example5-address" data-tid="elements_examples.form.address_placeholder" class="input" type="text" placeholder="185 Berry St" required="">
+                </div>
               </div>
-            </div>
-            <div class="row">
-              <div class="field">
-                <label for="example5-city" data-tid="elements_examples.form.city_label">City</label>
-                <input id="example5-city" data-tid="elements_examples.form.city_placeholder" class="input" type="text" placeholder="San Francisco" required="">
-              </div>
-              <div class="field">
-                <label for="example5-country" data-tid="elements_examples.form.country_label">Country</label>
-                <select id="example5-country" class="input">
-                  <option selected="selected" value="US" data-tid="elements_examples.form.country_placeholder">United States</option>
-                </select>
+              <div class="row" data-locale-reversible>
+                <div class="field">
+                  <label for="example5-city" data-tid="elements_examples.form.city_label">City</label>
+                  <input id="example5-city" data-tid="elements_examples.form.city_placeholder" class="input" type="text" placeholder="San Francisco" required="">
+                </div>
+                <div class="field">
+                  <label for="example5-state" data-tid="elements_examples.form.state_label">State</label>
+                  <input id="example5-state" data-tid="elements_examples.form.state_placeholder" class="input empty" type="text" placeholder="CA" required="">
+                </div>
+                <div class="field">
+                  <label for="example5-zip" data-tid="elements_examples.form.postal_code_label">ZIP</label>
+                  <input id="example5-zip" data-tid="elements_examples.form.postal_code_placeholder" class="input empty" type="text" placeholder="94107" required="">
+                </div>
               </div>
             </div>
             <div class="row">


### PR DESCRIPTION
Japanese addresses are ordered from least-specific to most-specific. This change reorders the fields using CSS when the language is set to Japanese.

Reviewing the PR with `?w=0` is helpful!