### PR TITLE
increase font size to 16px

### DIFF
--- a/css/example1.css
+++ b/css/example1.css
@@ -4,7 +4,7 @@
 
 .example.example1 * {
   font-family: Roboto, Open Sans, Segoe UI, sans-serif;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 500;
 }
 

--- a/css/example4.css
+++ b/css/example4.css
@@ -4,7 +4,7 @@
 
 .example.example4 * {
   font-family: Inter UI, Open Sans, Segoe UI, sans-serif;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 500;
 }
 

--- a/css/example5.css
+++ b/css/example5.css
@@ -4,7 +4,7 @@
 
 .example.example5 * {
   font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 400;
 }
 

--- a/js/example1.js
+++ b/js/example1.js
@@ -21,7 +21,7 @@
         color: '#fff',
         fontWeight: 500,
         fontFamily: 'Roboto, Open Sans, Segoe UI, sans-serif',
-        fontSize: '15px',
+        fontSize: '16px',
         fontSmoothing: 'antialiased',
 
         ':-webkit-autofill': {

--- a/js/example4.js
+++ b/js/example4.js
@@ -22,7 +22,7 @@
         color: "#32325D",
         fontWeight: 500,
         fontFamily: "Inter UI, Open Sans, Segoe UI, sans-serif",
-        fontSize: "15px",
+        fontSize: "16px",
         fontSmoothing: "antialiased",
 
         "::placeholder": {

--- a/js/example5.js
+++ b/js/example5.js
@@ -19,7 +19,7 @@
         color: "#fff",
         fontWeight: 400,
         fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
-        fontSize: "15px",
+        fontSize: "16px",
         fontSmoothing: "antialiased",
 
         "::placeholder": {


### PR DESCRIPTION
Font sizes <16px in input fields cause zoom when focused on mobile.

To avoid that, this PR bumps the font size of examples 1, 4 and 5 to 16px.
I left the padding the same as it was, everything still looks good!
 