### PR TITLE
Changed hostname to stripe.dev

### DIFF
--- a/js/l10n.js
+++ b/js/l10n.js
@@ -1,8 +1,8 @@
 // Simple localization
-const isGithubPages = window.location.hostname === 'stripe.github.io';
-const localeIndex = isGithubPages ? 2 : 1;
+const isStripeDev = window.location.hostname === 'stripe.dev';
+const localeIndex = isStripeDev ? 2 : 1;
 window.__exampleLocale = window.location.pathname.split('/')[localeIndex] || 'en';
-const urlPrefix = isGithubPages ? '/elements-examples/' : '/';
+const urlPrefix = isStripeDev ? '/elements-examples/' : '/';
 
 document.querySelectorAll('.optionList a').forEach(function(langNode) {
   const langValue = langNode.getAttribute('data-lang');


### PR DESCRIPTION
We moved stripe.github.io to permanently redirect to stripe.dev. Updated the l10n script so the language links had the correct relative path. 