### PR TITLE
Fix green flash when clicking input

### DIFF
--- a/css/example2.css
+++ b/css/example2.css
@@ -164,10 +164,6 @@
   cursor: pointer;
 }
 
-.example.example2 input:active {
-  background-color: #159570;
-}
-
 .example.example2 .error svg {
   margin-top: 0 !important;
 }


### PR DESCRIPTION
Removes active state CSS on example 2 non-elements inputs. This was causing a bug where clicking the input caused the background to flash green.