### PR TITLE
Use new font name

### DIFF
--- a/css/example4.css
+++ b/css/example4.css
@@ -3,7 +3,7 @@
 }
 
 .example.example4 * {
-  font-family: Inter UI, Open Sans, Segoe UI, sans-serif;
+  font-family: Inter, Open Sans, Segoe UI, sans-serif;
   font-size: 16px;
   font-weight: 500;
 }

--- a/js/example4.js
+++ b/js/example4.js
@@ -4,7 +4,7 @@
   var elements = stripe.elements({
     fonts: [
       {
-        cssSrc: "https://rsms.me/inter/inter-ui.css"
+        cssSrc: "https://rsms.me/inter/inter.css"
       }
     ],
     // Stripe's examples are localized to specific languages, but if
@@ -21,7 +21,7 @@
       base: {
         color: "#32325D",
         fontWeight: 500,
-        fontFamily: "Inter UI, Open Sans, Segoe UI, sans-serif",
+        fontFamily: "Inter, Open Sans, Segoe UI, sans-serif",
         fontSize: "16px",
         fontSmoothing: "antialiased",
 


### PR DESCRIPTION
The Inter font was renamed in February 2019 with [the release of version 3.3](https://github.com/rsms/inter/releases/tag/v3.3).