### PR TITLE
Use pointer events none on label

### DIFF
--- a/css/example2.css
+++ b/css/example2.css
@@ -50,6 +50,7 @@
   white-space: nowrap;
   transform-origin: 0 50%;
   cursor: text;
+  pointer-events: none;
   transition-property: color, transform;
   transition-duration: 0.3s;
   transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);


### PR DESCRIPTION
Use pointer events: none on the label for example 2 to allow the user-driven focus event to pass directly to the element.